### PR TITLE
Fix render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to the "stackstorm-vscode" extension will be documented in this file.
 
-##\[1.1.0] - 2019-03-04
+## \[1.1.1] - 2019-03-06
+### Fixed
+*  #18 - Fixed the generating of templates. This was tested however on a fresh install this did not work.
+
+## \[1.1.0] - 2019-03-04
 ### Added
 *  Added 'st2.defaultAuthor' setting which can be used to fill out the pack.yaml file.
 *  Added 'st2.defaultEmail' setting which can be used to fill out the pack.yaml file.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Stackstorm VS Code
 
+# Important notice
+It has become apparent that although in my testing the extension was working normally, when installed on a fresh install it did not.
+This has now been fixed. I apologise for this and hope that you will try this extension again.
+
+If you experence anymore issues please raise them at https://github.com/systemsmystery/stackstorm-vscode/issues
+
+---
+
 ![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/systemsmystery.stackstorm-vscode.svg?style=flat-square)
 ![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/systemsmystery.stackstorm-vscode.svg?style=flat-square)
 ![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/systemsmystery.stackstorm-vscode.svg?style=flat-square)
@@ -8,6 +16,7 @@
 [![GitHub](https://img.shields.io/github/release/systemsmystery/stackstorm-vscode.svg?style=flat-square)](https://github.com/systemsmystery/stackstorm-vscode/releases)
 [![BuyMeACoffee](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-brightgreen.svg?style=flat-square)](https://www.buymeacoffee.com/systemsmystery)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/92ac812f24fe4dffb8b78ae6f41387fa)](https://app.codacy.com/app/rj175/stackstorm-vscode?utm_source=github.com&utm_medium=referral&utm_content=systemsmystery/stackstorm-vscode&utm_campaign=Badge_Grade_Settings)
+
 
 This extension adds the ability to create the required files for a Stackstorm pack in a VS Code Workspace.
  > Inspired by [VS Code Angular Files](https://github.com/ivalexa/vscode-angular2-files/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "stackstorm-vscode",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1904,14 +1904,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1926,20 +1924,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2056,8 +2051,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2069,7 +2063,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2084,7 +2077,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2092,14 +2084,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2118,7 +2108,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2199,8 +2188,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2212,7 +2200,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2334,7 +2321,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3625,8 +3611,7 @@
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-			"dev": true
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"lodash._basecopy": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
 	"dependencies": {
 		"@types/classnames": "^2.2.7",
 		"@types/lodash": "^4.14.121",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"lodash": "^4.17.11"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"author": {
 		"name": "Richard Annand"
 	},
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"engines": {
 		"vscode": "^1.31.0"
 	},


### PR DESCRIPTION
Closes issue #18. Render was missing `lodash` package. This was installed as a dev dependency and not as a dependency for the project.